### PR TITLE
Creating MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE.md README.md requirements.txt setup.py .gitignore
+exclude setenvironment.py
+
+prune output*
+prune resources*

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name     = 'varsomdata',
       author   = 'NVE',
@@ -7,10 +7,7 @@ setup(name     = 'varsomdata',
       version  = '1.0.0',
       license  = 'MIT',
       url      = 'https://github.com/NVE/varsomdata',
-
-      packages = ['utilities',
-                  'varsomdata',
-                  'varsomscripts'],
-
-      install_requires = ['numpy>1.12.0', 'pandas>1.0.0', 'matplotlib>3.0.0']
+      install_requires = ['numpy>1.12.0', 'pandas>1.0.0', 'matplotlib>3.0.0'],
+      packages = find_packages(),
+      include_package_data=True, # check MANIFEST.in for explicit rules
      )


### PR DESCRIPTION
- Changing `setup.py` file to check for `MANIFEST.in` file

- `MANIFEST.in` file now includes and excludes correct files and directories for building source distribution

To test the source build, please run:
```python
python3 setup.py sdist
```

This will create a folder `dist/` which includes a tar file. From a Linux terminal, you can run:
```bash
tar -xvzf varsomedata-1.0.0.tar.gz
```
or to unpack it.

You should notice a couple of things:
1. The `examples/`, `utilities/`, `varsomdata/`, and `varsomscripts/` directories are included in the build. This means that the `output/` and `resources/` directories are not included, which was the point of setting up the `MANIFEST.in` file.

2. Additionally, the `experimental/`, `config`, `test` directories and the `setenvironment.py` file are not included. The `config` files are in the `.gitignore` file, so it did not make sense to include the `setenvironment.py` file which uses those files. However, this would be easy to include if we wanted any of these files or directories for the first release to PyPI.