### PR TITLE
WIP: Fixing one of the two remaining broken example scripts, working on the other

### DIFF
--- a/examples/ex_snow_profiles.py
+++ b/examples/ex_snow_profiles.py
@@ -11,6 +11,7 @@ __author__ = 'raek'
 
 # get snow profiles during a period
 snow_profiles = go.get_snow_profile('2018-12-13', '2018-12-26')
+#print(vars(snow_profiles[0]))
 
 # look for profiles with persistent weak layers. Loop through all.
 profiles_with_prec_weak_layers = []
@@ -32,7 +33,7 @@ for p in snow_profiles:
         # Large facets (FC > 3mm) qualifies.
         elif 'FC' in grain_form_name:
             if l.SortOrder > 0:
-                if l.GrainSizeAvg >= 0.003:
+                if l.GrainSizeAvg is not None and l.GrainSizeAvg >= 0.003:
                     profiles_with_prec_weak_layers.append(p)
 
 print("Profiles hinting of persistent weak layers: \n")

--- a/varsomdata/getforecastapi.py
+++ b/varsomdata/getforecastapi.py
@@ -877,6 +877,7 @@ def get_avalanche_warnings_deprecated(region_ids, from_date, to_date, lang_key=1
     avalanche_warning_list = []
     avalanche_danger_list = []
     exception_counter = 0
+    print(warnings_as_json[0], '\n')
 
     for w in warnings_as_json:
         #try:
@@ -920,6 +921,8 @@ def get_avalanche_warnings_deprecated(region_ids, from_date, to_date, lang_key=1
             warning.set_main_message_en(w['MainText'])
 
         if w['AvalancheProblems'] is not None:
+            if(w['AvalancheProblems'] is None):
+                print('Found None!')
             for p in w['AvalancheProblems']:
 
                 order = p['AvalancheProblemId']              # sort order of the avalanche problems in this forecast
@@ -979,7 +982,9 @@ def get_avalanche_warnings_deprecated(region_ids, from_date, to_date, lang_key=1
             lg.error("getForecastApi -> get_avalanche_warnings_deprecated: Exception at {0} of {1}".format(len(avalanche_warning_list) + exception_counter, len(warnings_as_json)))
             exception_counter += 1
         '''
-
+    print(vars(avalanche_danger_list[3]), '\n')
+    print(vars(avalanche_danger_list[4]), '\n')
+    print(vars(avalanche_danger_list[5]), '\n')
     return avalanche_danger_list
 
 

--- a/varsomdata/getproblems.py
+++ b/varsomdata/getproblems.py
@@ -142,12 +142,11 @@ def _map_warning_to_problem(warnings):
 
     for w in warnings:
 
-        region_id = w.region_id
+        region_id = w.region_regobs_id
         region_name = w.region_name
-        date = w.publish_time
+        date = w.date
 
         for p in w.avalanche_problems:
-
             order = p.avalanche_problem_id
             cause_name = p.aval_cause_name
             source = 'Forecast'
@@ -156,7 +155,7 @@ def _map_warning_to_problem(warnings):
             problem.set_regobs_table('AvalancheWarnProblem??')
             problem.set_regid(w.reg_id)
             problem.set_url('{0}{1}/{2}'.format(env.forecast_basestring, w.region_name, w.date_valid))
-            problem.set_registration_time(w.publish_time)
+            problem.set_registration_time(w.date)
             problem.set_nick_name(w.author)
 
             problem.set_cause_tid(p.aval_cause_id)
@@ -255,7 +254,7 @@ def get_all_problems(region_ids, from_date, to_date, add_danger_level=True, prob
         evaluations_2 = []
         eval_problems_2 = []
         warnings = gfa.get_avalanche_warnings_deprecated(region_ids=region_ids, from_date=from_date, to_date=to_date, lang_key=lang_key)
-
+        print(warnings[0])
     elif problems_from == 'Observation':
         evaluations_1 = go.get_avalanche_evaluation(region_ids=region_ids, from_date=from_date, to_date=to_date, lang_key=lang_key)
         evaluations_2 = go.get_avalanche_evaluation_2(region_ids=region_ids, from_date=from_date, to_date=to_date, lang_key=lang_key)


### PR DESCRIPTION
The first problematic file was `ex_snow_profiles.py`.

You can examine the error by running:
```python
python3 ex_snow_profiles.py
```

You then get back:
```bash
Traceback (most recent call last):
File "ex_snow_profiles.py", line 35, in <module>
if l.GrainSizeAvg >= 0.003:
TypeError: '>=' not supported between instances of 'NoneType' and 'float'
```

This error is caused by the fact that `l.GrainSizeAvg` can be `None`. So the comparison between `None` and a float causes the program to stop. A quick printout added to line 36

```python
print(grain_form_name, l.SortOrder, l.GrainSizeAvg) 
```
yields several results including:
```bash
FCxr 5 None
{'DepthTop': 0.53, 'Thickness': 0.04, 'GrainFormPrimaryTID': 25, 'GrainFormPrimaryName': 'FCxr', 'GrainFormSecondaryTID': 0, 'GrainFormSecondaryName': ' - ', 'GrainSizeAvg': None, 'GrainSizeAvgMax': None, 'HardnessTID': 10, 'HardnessName': '1F', 'HardnessBottomTID': None, 'HardnessBottomName': None, 'WetnessTID': 0, 'WetnessName': ' - ', 'CriticalLayerTID': None, 'CriticalLayerName': None, 'Comment': None, 'SortOrder': 5}
```
Changing line 36 to:
```python
if l.GrainSizeAvg is not None and l.GrainSizeAvg >= 0.003:
```
allows the program to complete, although more work is needed to determine if this is the correct fix (i.e., should we be using `np.nan` instead of `None`).

**NB**: There is still an issue with `ex_problemsanddangers.py` that I am working on, so this pull request is a work in progress.